### PR TITLE
Add linux to line about gradlew

### DIFF
--- a/source/developerIntro/fullWorkspace.rst
+++ b/source/developerIntro/fullWorkspace.rst
@@ -11,7 +11,7 @@ To set up the workspace is a fairly easy process:
 
 .. note::
 
-  In OSX, the command is ``./gradlew`` instand of ``gradlew``
+  In OSX and Linux, the command is ``./gradlew`` instand of ``gradlew``
 
 That's it, really! You now should have a functioning game workspace.
 


### PR DESCRIPTION
I thought that because of how opensource oriented terasolgy is that it would be only fair to have The opensource OS that is linux.