### PR TITLE
Add about using EnitiyRef without Sender annotation

### DIFF
--- a/source/developing/entitySystem/commands.rst
+++ b/source/developing/entitySystem/commands.rst
@@ -98,7 +98,7 @@ A command can be marked as ``runOnServer``, in which case it will be replicated 
 
 .. note::
 
-  In such a case, the command method can have a ``final EntityRef`` parameter. This will be populated with the Client entity of the calling player.
+  In such a case, the command method can have a ``final EntityRef`` parameter with ``@Sender`` annotation. This will be populated with the Client entity of the calling player. If the annotation is missing the command it will be logged that there is a command using ``final EntityRef`` but does not have the annotation. Running such a command will return a ``NullPointerException``.
 
   .. code-block:: java
 


### PR DESCRIPTION
The PR MovingBlocks/Terasology#3123 adds a logger for commands using the `EntityRef` parameters without the `@Sender` annotation as they may throw a `NullPointerException`.